### PR TITLE
Fix asterisk install by adding apt cache update

### DIFF
--- a/roles/asterisk/tasks/main.yml
+++ b/roles/asterisk/tasks/main.yml
@@ -4,7 +4,7 @@
   notify: restart asterisk
 
 - name: install asterisk
-  apt: name=asterisk state=present
+  apt: name=asterisk state=present update_cache=yes
 
 - name: copy some config files
   copy: src={{ item }}.conf dest=/etc/asterisk/{{ item }}.conf owner=asterisk group=asterisk mode=0640


### PR DESCRIPTION
On a fresh ubuntu install, it appears that apt can't find the asterisk package, unless the apt cache is updated, so i added the cache update in the call to the ansible apt module